### PR TITLE
Compiler: generate string constants as Erlang binaries

### DIFF
--- a/compiler/cpp/src/generate/t_erlang_generator.cc
+++ b/compiler/cpp/src/generate/t_erlang_generator.cc
@@ -547,7 +547,7 @@ string t_erlang_generator::render_const_value(t_type* type, t_const_value* value
     t_base_type::t_base tbase = ((t_base_type*)type)->get_base();
     switch (tbase) {
     case t_base_type::TYPE_STRING:
-      out << '"' << get_escaped_string(value) << '"';
+      out << "<<\"" << get_escaped_string(value) << "\">>";
       break;
     case t_base_type::TYPE_BOOL:
       out << (value->get_integer() > 0 ? "true" : "false");


### PR DESCRIPTION
thrift runtime expects binaries for the string constants
