### PR TITLE
Fix Erlang unions, constants, filenaming, types generation

### DIFF
--- a/compiler/cpp/src/generate/t_erlang_generator.cc
+++ b/compiler/cpp/src/generate/t_erlang_generator.cc
@@ -602,7 +602,7 @@ string t_erlang_generator::render_const_value(t_type* type, std::string name, t_
     t_base_type::t_base tbase = ((t_base_type*)type)->get_base();
     switch (tbase) {
     case t_base_type::TYPE_STRING:
-      out << '"' << get_escaped_string(value) << '"';
+      out << "<<\"" << get_escaped_string(value) << "\">>";
       break;
     case t_base_type::TYPE_BOOL:
       out << (value->get_integer() > 0 ? "true" : "false");

--- a/lib/erlang/include/thrift_constants.hrl
+++ b/lib/erlang/include/thrift_constants.hrl
@@ -41,7 +41,7 @@
 
 % TApplicationException
 -define(TApplicationException_Structure,
-        {struct, [{1, undefined, string, undefined, undefined},
+        {struct, exception, [{1, undefined, string, undefined, undefined},
                   {2, undefined, i32, undefined, undefined}]}).
 
 -record('TApplicationException', {message, type}).

--- a/lib/erlang/include/thrift_protocol_behaviour.hrl
+++ b/lib/erlang/include/thrift_protocol_behaviour.hrl
@@ -23,7 +23,7 @@
 -define(THRIFT_PROTOCOL_BEHAVIOUR_INCLUDED, true).
 
 -spec flush_transport(state()) -> {state(), ok | {error, _Reason}}.
--spec close_transport(state()) -> {state(), ok | {error, _Reason}}.
+-spec close_transport(state()) -> {state(), any()}.
 
 -spec write(state(), any()) -> {state(), ok | {error, _Reason}}.
 

--- a/lib/erlang/src/thrift_client.erl
+++ b/lib/erlang/src/thrift_client.erl
@@ -57,10 +57,10 @@ send_call(Client = #tclient{}, Function, Args)
       Else -> Else
     end.
 
--spec close(#tclient{}) -> ok.
-close(#tclient{protocol=Protocol}) ->
-    thrift_protocol:close_transport(Protocol).
-
+-spec close(#tclient{}) -> {#tclient{}, _Result}.
+close(Client = #tclient{protocol=Protocol}) ->
+    {Protocol2, Result} = thrift_protocol:close_transport(Protocol),
+    {Client#tclient{protocol=Protocol2}, Result}.
 
 %%--------------------------------------------------------------------
 %%% Internal functions

--- a/lib/erlang/src/thrift_client.erl
+++ b/lib/erlang/src/thrift_client.erl
@@ -34,7 +34,7 @@ new(Protocol, Service = {Module, ServiceName})
                   service = Service,
                   seqid = 0}}.
 
--spec call(#tclient{}, atom(), list()) -> {#tclient{}, {ok, any()} | {error, any()}}.
+-spec call(#tclient{}, atom(), list()) -> {#tclient{}, {ok, any()} | {error, any()}} | no_return().
 call(Client = #tclient{}, Function, Args)
 when is_atom(Function), is_list(Args) ->
   case send_function_call(Client, Function, Args) of
@@ -84,7 +84,7 @@ send_function_call(Client = #tclient{service = Service}, Function, Args) ->
       write_message(Client, Function, Args, Params, MsgType)
   end.
 
--spec write_message(#tclient{}, atom(), list(), {struct, list()}, integer()) ->
+-spec write_message(#tclient{}, atom(), list(), {struct, struct, list()}, integer()) ->
   {ok | {error, any()}, #tclient{}}.
 write_message(Client = #tclient{protocol = P0, seqid = Seq}, Function, Args, Params, MsgType) ->
   try
@@ -116,7 +116,7 @@ write_many(Proto, [Data | Rest]) ->
 write_many(Proto, []) ->
     {Proto, ok}.
 
--spec receive_function_result(#tclient{}, atom()) -> {#tclient{}, {ok, any()} | {error, any()}}.
+-spec receive_function_result(#tclient{}, atom()) -> {#tclient{}, {ok, any()} | {error, any()}} | no_return().
 receive_function_result(Client = #tclient{service = Service}, Function) ->
     ResultType = get_function_info(Service, Function, reply_type),
     read_result(Client, Function, ResultType).
@@ -151,9 +151,9 @@ handle_reply(Client = #tclient{protocol = Proto0,
              ReplyType) ->
     {struct, _, ExceptionFields} = get_function_info(Service, Function, exceptions),
     ReplyStructDef = {struct, struct, [{0, undefined, ReplyType, undefined, undefined}] ++ ExceptionFields},
-    io:format("reply struct: ~p~n", [ReplyStructDef]),
+    %% io:format("reply struct: ~p~n", [ReplyStructDef]),
     {Proto1, {ok, Reply}} = thrift_protocol:read(Proto0, ReplyStructDef),
-    io:format("reply: ~p~n", [Reply]),
+    %% io:format("reply: ~p~n", [Reply]),
     {Proto2, ok} = thrift_protocol:read(Proto1, message_end),
     NewClient = Client#tclient{protocol = Proto2},
     ReplyList = tuple_to_list(Reply),

--- a/lib/erlang/src/thrift_protocol.erl
+++ b/lib/erlang/src/thrift_protocol.erl
@@ -56,11 +56,11 @@ flush_transport(Proto = #protocol{module = Module,
     {NewData, Result} = Module:flush_transport(Data),
     {Proto#protocol{data = NewData}, Result}.
 
--spec close_transport(#protocol{}) -> _Result.
-close_transport(#protocol{module = Module,
+-spec close_transport(#protocol{}) -> {#protocol{}, _Result}.
+close_transport(Proto = #protocol{module = Module,
                           data = Data}) ->
-    {_, Result} = Module:close_transport(Data),
-    Result.
+    {Data1, Result} = Module:close_transport(Data),
+    {Proto#protocol{data = Data1}, Result}.
 
 typeid_to_atom(?tType_STOP) -> field_stop;
 typeid_to_atom(?tType_VOID) -> void;

--- a/lib/erlang/src/thrift_protocol.erl
+++ b/lib/erlang/src/thrift_protocol.erl
@@ -93,7 +93,7 @@ term_to_typeid({list, _}) -> ?tType_LIST.
 
 %% Structure is like:
 %%    [{Fid, Type}, ...]
--spec read(#protocol{}, {struct, _Flavor, _StructDef}, atom()) -> {#protocol{}, {ok, tuple()}}.
+-spec read(#protocol{}, {struct, _Flavour, _StructDef}, atom()) -> {#protocol{}, {ok, tuple()}}.
 read(IProto0, {struct, union, StructDef}, _Tag)
   when is_list(StructDef) ->
     {IProto1, RTuple} = read_union_loop(IProto0, enumerate(1, StructDef)),
@@ -125,7 +125,7 @@ enumerate(_, []) ->
 
 %% NOTE: Keep this in sync with thrift_protocol_behaviour:read
 -spec read
-        (#protocol{}, {struct, _Flavor, _Info}) -> {#protocol{}, {ok, tuple()}      | {error, _Reason}};
+        (#protocol{}, {struct, _Flavour, _Info}) -> {#protocol{}, {ok, tuple()}      | {error, _Reason}};
         (#protocol{}, tprot_cont_tag()) ->         {#protocol{}, {ok, any()}        | {error, _Reason}};
         (#protocol{}, tprot_empty_tag()) ->        {#protocol{},  ok                | {error, _Reason}};
         (#protocol{}, tprot_header_tag()) ->       {#protocol{}, tprot_header_val() | {error, _Reason}};
@@ -346,7 +346,7 @@ skip_list_loop(Proto0, Map = #protocol_list_begin{etype = Etype, size = Size}) -
 %%--------------------------------------------------------------------
 %% Function: write(OProto, {Type, Data}) -> ok
 %%
-%% Type = {struct, Flavor, StructDef} |
+%% Type = {struct, Flavour, StructDef} |
 %%        {list, Type} |
 %%        {map, KeyType, ValType} |
 %%        {set, Type} |
@@ -478,7 +478,7 @@ struct_write_loop(Proto, [], []) ->
 -spec validate(tprot_header_val() | tprot_header_tag() | tprot_empty_tag() | field_stop | TypeData) ->
     ok | {error, {invalid, Location :: [atom()], Value :: term()}} when
         TypeData :: {Type, Data},
-        Type :: tprot_data_tag() | tprot_cont_tag() | {enum, _Def} | {struct, _Flavor, _Def},
+        Type :: tprot_data_tag() | tprot_cont_tag() | {enum, _Def} | {struct, _Flavour, _Def},
         Data :: term().
 
 validate(#protocol_message_begin{}) -> ok;
@@ -526,14 +526,14 @@ validate(_Req, {{struct, union, StructDef} = Type, Data = {Name, Value}}, Path)
         false ->
             throw({invalid, Path, Type, Data})
     end;
-validate(Req, {{struct, _Flavor, {Mod, Name}}, Data}, Path)
+validate(Req, {{struct, _Flavour, {Mod, Name}}, Data}, Path)
   when element(1, Data) =:= Name ->
     validate(Req, {Mod:struct_info(Name), Data}, Path);
-validate(_Req, {{struct, _Flavor, StructDef}, Data}, Path)
+validate(_Req, {{struct, _Flavour, StructDef}, Data}, Path)
   when is_list(StructDef) andalso tuple_size(Data) =:= length(StructDef) + 1 ->
     [_ | Elems] = tuple_to_list(Data),
     validate_struct_fields(StructDef, Elems, Path);
-validate(_Req, {{struct, _Flavor, StructDef}, Data}, Path)
+validate(_Req, {{struct, _Flavour, StructDef}, Data}, Path)
   when is_list(StructDef) andalso tuple_size(Data) =:= length(StructDef) ->
     validate_struct_fields(StructDef, tuple_to_list(Data), Path);
 validate(_Req, {{enum, _Fields}, Value}, _Path) when is_atom(Value), Value =/= undefined ->

--- a/lib/erlang/src/thrift_protocol.erl
+++ b/lib/erlang/src/thrift_protocol.erl
@@ -56,10 +56,11 @@ flush_transport(Proto = #protocol{module = Module,
     {NewData, Result} = Module:flush_transport(Data),
     {Proto#protocol{data = NewData}, Result}.
 
--spec close_transport(#protocol{}) -> ok.
+-spec close_transport(#protocol{}) -> _Result.
 close_transport(#protocol{module = Module,
                           data = Data}) ->
-    Module:close_transport(Data).
+    {_, Result} = Module:close_transport(Data),
+    Result.
 
 typeid_to_atom(?tType_STOP) -> field_stop;
 typeid_to_atom(?tType_VOID) -> void;

--- a/lib/erlang/src/thrift_protocol.erl
+++ b/lib/erlang/src/thrift_protocol.erl
@@ -541,7 +541,22 @@ validate(_Req, {string, Value}, _Path) when is_binary(Value) ->
     ok;
 validate(_Req, {bool, Value}, _Path) when is_boolean(Value) ->
     ok;
-validate(_Req, {_Type, Value}, _Path) when is_number(Value) ->
+validate(_Req, {byte, Value}, _Path)
+  when is_integer(Value), Value >= -(1 bsl 7), Value < (1 bsl 7) ->
+    ok;
+validate(_Req, {i8,  Value}, _Path)
+  when is_integer(Value), Value >= -(1 bsl 7), Value < (1 bsl 7) ->
+    ok;
+validate(_Req, {i16, Value}, _Path)
+  when is_integer(Value), Value >= -(1 bsl 15), Value < (1 bsl 15) ->
+    ok;
+validate(_Req, {i32, Value}, _Path)
+  when is_integer(Value), Value >= -(1 bsl 31), Value < (1 bsl 31) ->
+    ok;
+validate(_Req, {i64, Value}, _Path)
+  when is_integer(Value), Value >= -(1 bsl 63), Value < (1 bsl 63) ->
+    ok;
+validate(_Req, {double, Value}, _Path) when is_float(Value) ->
     ok;
 validate(_Req, {Type, Value}, Path) ->
     throw({invalid, Path, Type, Value}).

--- a/lib/erlang/test/test_disklog.erl
+++ b/lib/erlang/test/test_disklog.erl
@@ -37,7 +37,7 @@ disklog_test() ->
 
   % We have to make oneway calls into this client only since otherwise it
   % will try to read from the disklog and go boom.
-  {Client1, {ok, ok}} = thrift_client:call(Client0, testOneway, [16#deadbeef]),
+  {Client1, {ok, ok}} = thrift_client:call(Client0, testOneway, [16#7eadbeef]),
   io:format("Call written~n"),
 
   % Use the send_call method to write a non-oneway call into the log
@@ -76,7 +76,7 @@ disklog_base64_test() ->
 
   % We have to make oneway calls into this client only since otherwise
   % it will try to read from the disklog and go boom.
-  {Client1, {ok, ok}} = thrift_client:call(Client0, testOneway, [16#deadbeef]),
+  {Client1, {ok, ok}} = thrift_client:call(Client0, testOneway, [16#7eadbeef]),
   io:format("Call written~n"),
 
   % Use the send_call method to write a non-oneway call into the log


### PR DESCRIPTION
- Fix scoping for constants
- Fix generated files naming
- Fix Union constants rendering
- Add 'scoped_typenames' and 'app_prefix' options
